### PR TITLE
Add RSVP endpoints and RsvpService

### DIFF
--- a/api/EventPlanner.Api/Controllers/RsvpsController.cs
+++ b/api/EventPlanner.Api/Controllers/RsvpsController.cs
@@ -1,0 +1,44 @@
+using EventPlanner.Api.DTOs;
+using EventPlanner.Api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace EventPlanner.Api.Controllers;
+
+[ApiController]
+[Route("api/rsvps")]
+[Authorize]
+public class RsvpsController : ControllerBase
+{
+    private readonly IRsvpService _rsvpService;
+
+    public RsvpsController(IRsvpService rsvpService)
+    {
+        _rsvpService = rsvpService;
+    }
+
+    [HttpGet("my")]
+    public async Task<IActionResult> GetMyRsvps()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        var rsvps = await _rsvpService.GetMyRsvpsAsync(userId);
+        return Ok(rsvps);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create(CreateRsvpRequest request)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        var rsvp = await _rsvpService.CreateAsync(request, userId);
+        return StatusCode(201, rsvp);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        await _rsvpService.DeleteAsync(id, userId);
+        return NoContent();
+    }
+}

--- a/api/EventPlanner.Api/DTOs/CreateRsvpRequest.cs
+++ b/api/EventPlanner.Api/DTOs/CreateRsvpRequest.cs
@@ -1,0 +1,9 @@
+using EventPlanner.Api.Models;
+
+namespace EventPlanner.Api.DTOs;
+
+public class CreateRsvpRequest
+{
+    public int EventId { get; set; }
+    public Rsvp.RsvpStatus Status { get; set; }
+}

--- a/api/EventPlanner.Api/DTOs/RsvpResponse.cs
+++ b/api/EventPlanner.Api/DTOs/RsvpResponse.cs
@@ -1,0 +1,11 @@
+using EventPlanner.Api.Models;
+
+namespace EventPlanner.Api.DTOs;
+
+public class RsvpResponse
+{
+    public int Id { get; set; }
+    public int EventId { get; set; }
+    public string EventTitle { get; set; } = string.Empty;
+    public Rsvp.RsvpStatus Status { get; set; }
+}

--- a/api/EventPlanner.Api/Middleware/ExceptionMiddleware.cs
+++ b/api/EventPlanner.Api/Middleware/ExceptionMiddleware.cs
@@ -29,6 +29,7 @@ public class ExceptionMiddleware(RequestDelegate next, ILogger<ExceptionMiddlewa
         {
             NotFoundException => (int)HttpStatusCode.NotFound,
             ForbiddenException => (int)HttpStatusCode.Forbidden,
+            InvalidOperationException => (int)HttpStatusCode.Conflict,
             _ => (int)HttpStatusCode.InternalServerError
         };
 
@@ -38,7 +39,7 @@ public class ExceptionMiddleware(RequestDelegate next, ILogger<ExceptionMiddlewa
         var response = new
         {
             status = statusCode,
-            message = exception is NotFoundException or ForbiddenException
+            message = exception is NotFoundException or ForbiddenException or InvalidOperationException
                 ? exception.Message
                 : "An unexpected error occurred."
         };

--- a/api/EventPlanner.Api/Program.cs
+++ b/api/EventPlanner.Api/Program.cs
@@ -80,6 +80,7 @@ builder.Services.AddAuthentication(options => {
 
 builder.Services.AddScoped<ITokenService, TokenService>();
 builder.Services.AddScoped<IEventService, EventService>();
+builder.Services.AddScoped<IRsvpService, RsvpService>();
 
 var app = builder.Build();
 app.UseMiddleware<ExceptionMiddleware>();

--- a/api/EventPlanner.Api/Services/IRsvpService.cs
+++ b/api/EventPlanner.Api/Services/IRsvpService.cs
@@ -1,0 +1,10 @@
+using EventPlanner.Api.DTOs;
+
+namespace EventPlanner.Api.Services;
+
+public interface IRsvpService
+{
+    Task<IEnumerable<RsvpResponse>> GetMyRsvpsAsync(string userId);
+    Task<RsvpResponse> CreateAsync(CreateRsvpRequest request, string userId);
+    Task DeleteAsync(int id, string userId);
+}

--- a/api/EventPlanner.Api/Services/RsvpService.cs
+++ b/api/EventPlanner.Api/Services/RsvpService.cs
@@ -1,0 +1,73 @@
+using EventPlanner.Api.Data;
+using EventPlanner.Api.DTOs;
+using EventPlanner.Api.Exceptions;
+using EventPlanner.Api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace EventPlanner.Api.Services;
+
+public class RsvpService : IRsvpService
+{
+    private readonly AppDbContext _db;
+
+    public RsvpService(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<IEnumerable<RsvpResponse>> GetMyRsvpsAsync(string userId)
+    {
+        return await _db.Rsvps
+            .Include(r => r.Event)
+            .Where(r => r.UserId == userId)
+            .Select(r => ToResponse(r))
+            .ToListAsync();
+    }
+
+    public async Task<RsvpResponse> CreateAsync(CreateRsvpRequest request, string userId)
+    {
+        var eventExists = await _db.Events.AnyAsync(e => e.Id == request.EventId);
+        if (!eventExists)
+            throw new NotFoundException($"Event with ID {request.EventId} was not found.");
+
+        var duplicate = await _db.Rsvps.AnyAsync(r => r.UserId == userId && r.EventId == request.EventId);
+        if (duplicate)
+            throw new InvalidOperationException("You have already RSVP'd to this event.");
+
+        var rsvp = new Rsvp
+        {
+            UserId = userId,
+            EventId = request.EventId,
+            Status = request.Status
+        };
+
+        _db.Rsvps.Add(rsvp);
+        await _db.SaveChangesAsync();
+
+        await _db.Entry(rsvp).Reference(r => r.Event).LoadAsync();
+
+        return ToResponse(rsvp);
+    }
+
+    public async Task DeleteAsync(int id, string userId)
+    {
+        var rsvp = await _db.Rsvps.FindAsync(id);
+
+        if (rsvp == null)
+            throw new NotFoundException($"RSVP with ID {id} was not found.");
+
+        if (rsvp.UserId != userId)
+            throw new ForbiddenException("You do not have permission to cancel this RSVP.");
+
+        _db.Rsvps.Remove(rsvp);
+        await _db.SaveChangesAsync();
+    }
+
+    private static RsvpResponse ToResponse(Rsvp rsvp) => new()
+    {
+        Id = rsvp.Id,
+        EventId = rsvp.EventId,
+        EventTitle = rsvp.Event?.Title ?? string.Empty,
+        Status = rsvp.Status
+    };
+}


### PR DESCRIPTION
How to test manually:

Run the API and test these in Swagger:

1. Without a token - GET `/api/rsvps/my` should return `401`
2. Log in via POST `/api/auth/login` to get a token, authorize in Swagger
3. GET `/api/rsvps/my` - should return an empty array
4. POST `/api/rsvps` - RSVP to a seeded event (pick a valid `eventId` from `GET /api/events`)
5. POST `/api/rsvps` again with the same eventId - should return `409` with "You have already RSVP'd to this event."
6. POST `/api/rsvps` with a non-existent `eventId` - should return `404`
7. GET `/api/rsvps/my` - should now show the RSVP you created
8. DELETE `/api/rsvps/{id}` - cancel it, should return `204`