### PR TITLE
test: fix async timing and text mismatch in App.test

### DIFF
--- a/client/tests/App.test.jsx
+++ b/client/tests/App.test.jsx
@@ -8,7 +8,7 @@ vi.mock('../src/api/client', () => ({
   default: { get: vi.fn().mockResolvedValue({ data: [] }), post: vi.fn() }
 }));
 
-test('renders Events Page header', () => {
+test('renders Events Page header', async () => {
   render(
     <BrowserRouter>
       <AuthProvider>
@@ -18,6 +18,6 @@ test('renders Events Page header', () => {
   );
   
   // Changed "Event Planner" to "Events Page" to match your code
-  const headerElement = screen.getByText(/events page/i);
+  const headerElement = await screen.findByText(/^events$/i);
   expect(headerElement).toBeInTheDocument();
 });


### PR DESCRIPTION
Got an error because it used getByText which doesn't wait for asynchronous updates. Since EventsPage fetches data and shows a "Loading..." state first, the test couldn't find the header.

Changes:
Switched getByText to findByText to handle the async loading.
Updated the text matcher to match the actual "h1>Events</h1" in the component.